### PR TITLE
fix: update graddle format and commands

### DIFF
--- a/burp-send-to-extension/build.gradle
+++ b/burp-send-to-extension/build.gradle
@@ -10,17 +10,16 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile 'com.intellij:forms_rt:7.0.3'
-    compile 'net.portswigger.burp.extender:burp-extender-api:1.7.22'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
-    compile group: 'com.google.guava', name: 'guava', version: '27.0.1-jre'
-
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    implementation 'com.intellij:forms_rt:7.0.3'
+    implementation 'net.portswigger.burp.extender:burp-extender-api:1.7.22'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    implementation group: 'com.google.guava', name: 'guava', version: '27.0.1-jre'
 }
 
 task fatJar(type: Jar) {
-    baseName = project.name
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    archiveFileName = "${project.name}-fat.jar"
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 


### PR DESCRIPTION
I've updated the .gradle file format to one that is compatible with the latest version and is able to compile with a:

`gradle build`